### PR TITLE
Redesign CI pipeline to utilize tox environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: tox r -vv --notest
 
       - name: Run test suite
-        run: tox r --env lint --skip-pkg-install
+        run: tox r -e lint --skip-pkg-install
         env:
           PYTEST_ADDOPTS: "-vv --durations=10"
 
@@ -55,7 +55,7 @@ jobs:
         run: tox r -vv --notest
 
       - name: Run test suite
-        run: tox r --env fix --skip-pkg-install
+        run: tox r -e fix --skip-pkg-install
         env:
           PYTEST_ADDOPTS: "-vv --durations=10"
 
@@ -90,7 +90,7 @@ jobs:
         run: tox r -vv --notest
 
       - name: Run test suite
-        run: tox r --env ${{ matrix.py }} --skip-pkg-install
+        run: tox r -e ${{ matrix.py }} --skip-pkg-install
         env:
           PYTEST_ADDOPTS: "-vv --durations=10"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup test suite
         run: tox r -vv --notest
 
-      - name: Run test suite
+      - name: Run linting suite
         run: tox r -e lint --skip-pkg-install
         env:
           PYTEST_ADDOPTS: "-vv --durations=10"
@@ -54,7 +54,7 @@ jobs:
       - name: Setup test suite
         run: tox r -vv --notest
 
-      - name: Run test suite
+      - name: Run fixing suite
         run: tox r -e fix --skip-pkg-install
         env:
           PYTEST_ADDOPTS: "-vv --durations=10"
@@ -93,27 +93,3 @@ jobs:
         run: tox r -e ${{ matrix.py }} --skip-pkg-install
         env:
           PYTEST_ADDOPTS: "-vv --durations=10"
-
-  lint:
-    name: Linting Code Base
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install flake8 flake8-bugbear flake8-docstrings flake8-github-annotations yamllint
-
-      - name: Lint with yamllint
-        run: |
-          yamllint . --format github
-
-      - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --format github
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --format github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,58 @@ permissions:
   contents: read
 
 jobs:
-  tox:
-    name: Test on Python ${{ matrix.py }}
+  tox-lint:
+    name: Linting Code Base
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Setup python for lint environment
+        uses: actions/setup-python@v7
+
+      - name: Install tox-gh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox-gh
+
+      - name: Setup test suite
+        run: tox r -vv --notest
+
+      - name: Run test suite
+        run: tox r --env lint --skip-pkg-install
+        env:
+          PYTEST_ADDOPTS: "-vv --durations=10"
+
+  tox-fix:
+    name: Fixing Code Base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Setup python for fix environment
+        uses: actions/setup-python@v7
+
+      - name: Install tox-gh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox-gh
+
+      - name: Setup test suite
+        run: tox r -vv --notest
+
+      - name: Run test suite
+        run: tox r --env fix --skip-pkg-install
+        env:
+          PYTEST_ADDOPTS: "-vv --durations=10"
+
+  tox-testing:
+    name: Testing Code Base on Python ${{ matrix.py }}
+    runs-on: ubuntu-latest
+    needs:
+      - tox-lint
+      - tox-fix
     strategy:
       fail-fast: false
       matrix:
@@ -41,7 +90,7 @@ jobs:
         run: tox r -vv --notest
 
       - name: Run test suite
-        run: tox r --skip-pkg-install
+        run: tox r --env ${{ matrix.py }} --skip-pkg-install
         env:
           PYTEST_ADDOPTS: "-vv --durations=10"
 


### PR DESCRIPTION
This pull request restructures the CI workflow to separate linting, code fixing, and testing into distinct jobs, improving clarity and maintainability. The testing job now explicitly depends on the completion of linting and fixing jobs, and job names and commands have been updated for precision.

**CI Workflow Improvements:**

* Split the original `tox` job into three separate jobs: `tox-lint` (for linting), `tox-fix` (for code fixing), and `tox-testing` (for running tests), each with clear naming and dedicated steps. (`.github/workflows/ci.yml`)
* Updated the `tox-testing` job to depend on the successful completion of both `tox-lint` and `tox-fix`, ensuring code quality checks before running tests. (`.github/workflows/ci.yml`)
* Modified the test command in `tox-testing` to specify the environment using `${{ matrix.py }}` for more accurate test execution. (`.github/workflows/ci.yml`)